### PR TITLE
1.13.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  build: libprotobuf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  build: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "onnx" %}
-{% set version = "1.12.0" %}
-{% set sha256 = "052ad3d5dad358a33606e0fc89483f8150bb0655c99b12a43aa58b5b7f0cc507" %}
+{% set version = "1.13.0" %}
+{% set sha256 = "66eb61fc0ff4b6189816eb8e4da52e1e6775a1c29f372cbd08b694aa5b4ca978" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - check-model = onnx.bin.checker:check_model
     - check-node = onnx.bin.checker:check_node

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,9 @@ requirements:
     - pytest-runner
     - ninja
     - pybind11
-    - numpy
+    - numpy   1.19  # [py<310]
+    - numpy   1.21  # [py==310]
+    - numpy   1.23  # [py>=311]
   run:
     - python
     - protobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,6 @@ about:
     built-in operators and standard data types. Initially we focus on the
     capabilities needed for inferencing (evaluation).
   doc_url: https://github.com/onnx/onnx/blob/main/README.md
-  doc_source_url: https://github.com/onnx/onnx/tree/main/docs
   dev_url: https://github.com/onnx/onnx
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,8 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - protobuf 3.20.3
-    - libprotobuf 3.20.3
+    - protobuf
+    - libprotobuf
     - pytest-runner 4.4
     - pybind11 2.9.2
     - numpy   1.19  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,16 +31,16 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - protobuf
-    - libprotobuf
-    - pytest-runner
-    - pybind11
+    - protobuf 3.20.3
+    - libprotobuf 3.20.3
+    - pytest-runner 4.4
+    - pybind11 2.9.2
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]
   run:
     - python
-    - protobuf
+    - protobuf >=3.20.2,<4
     - {{ pin_compatible('libprotobuf') }}
     - {{ pin_compatible('numpy') }}
     - typing-extensions >=3.6.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - protobuf
     - libprotobuf
     - pytest-runner
-    - ninja
     - pybind11
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
@@ -44,7 +43,6 @@ requirements:
     - protobuf
     - {{ pin_compatible('libprotobuf') }}
     - {{ pin_compatible('numpy') }}
-    - six
     - typing-extensions >=3.6.2.1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "onnx" %}
 {% set version = "1.13.0" %}
-{% set sha256 = "b9e293b95cc4ae13f6edf1d5df9f0cfbf6bb0a373d72c073aa2f139ecd811b7e" %}
+{% set sha256 = "66eb61fc0ff4b6189816eb8e4da52e1e6775a1c29f372cbd08b694aa5b4ca978" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "onnx" %}
 {% set version = "1.13.0" %}
-{% set sha256 = "66eb61fc0ff4b6189816eb8e4da52e1e6775a1c29f372cbd08b694aa5b4ca978" %}
+{% set sha256 = "b9e293b95cc4ae13f6edf1d5df9f0cfbf6bb0a373d72c073aa2f139ecd811b7e" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,6 @@ build:
     - check-model = onnx.bin.checker:check_model
     - check-node = onnx.bin.checker:check_node
     - backend-test-tools = onnx.backend.test.cmd_tools:main
-  ignore_run_exports:
-    - libprotobuf  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
# onnx 1.13.0
upstream: https://github.com/onnx/onnx/tree/v1.13.0
`requirements.txt`: https://github.com/onnx/onnx/blob/v1.13.0/requirements.txt

## Changes
- Bump version and SHA
- Remove unnecessary `ignore_run_exports`
- Update dependencies

## Notes
- Adds python 3.11 support
- `abs.yaml` file to be removed before merging (or after https://github.com/AnacondaRecipes/protobuf-feedstock/pull/18)
- Linter complains of pinnings in host section. All deps w/o pinnings are in CBC or are python build tools
