### PR TITLE
1.13.0.b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,8 @@ requirements:
     - protobuf
     - libprotobuf
     - pytest-runner 4.4
-    - pybind11 2.9.2
+    - pybind11 2.9.2   # [py<311]
+    - pybind11 2.10.1  # [py>=311]
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - check-model = onnx.bin.checker:check_model
     - check-node = onnx.bin.checker:check_node

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,11 +29,10 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - pybind11
     - protobuf
     - libprotobuf
     - pytest-runner 4.4
-    - pybind11 2.9.2   # [py<311]
-    - pybind11 2.10.1  # [py>=311]
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]


### PR DESCRIPTION
- Adjust host pinning for `pybind11` for python 3.11
    - `2.10.1` is the first version compatible with 3.11: https://github.com/pybind/pybind11/releases/tag/v2.10.1
    
 Edit: Per https://github.com/AnacondaRecipes/onnx-feedstock/pull/8#discussion_r1096119889 pybind11 doesn't need a pinning