### PR TITLE
onnx 1.13.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,6 @@
-  
+:: cmd
+echo "Building %PKG_NAME%."
+
 set "ONNX_ML=1"
 set CONDA_PREFIX=%LIBRARY_PREFIX%
 set CMAKE_GENERATOR="Visual Studio 15 2017"
@@ -7,4 +9,4 @@ set CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DProtobuf_USE_STATIC_LIBS=OF
 set "PYTHON_EXECUTABLE=%PYTHON%"
 set "PYTHON_LIBRARIES=%LIBRARY_LIB%"
 set USE_MSVC_STATIC_RUNTIME=0
-%PYTHON% -m pip install --no-deps --no-use-pep517 --ignore-installed --verbose .
+%PYTHON% -m pip install --no-deps --no-use-pep517 --ignore-installed --no-build-isolation --verbose .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
+#!/bin/sh
+
 export ONNX_ML=1
 # build script looks at this, but not set on
 export CONDA_PREFIX="$PREFIX"
 export CMAKE_ARGS="${CMAKE_ARGS} -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc -DProtobuf_LIBRARY=$PREFIX/lib/libprotobuf${SHLIB_EXT}"
-$PYTHON -m pip install --no-deps --ignore-installed --verbose .
+$PYTHON -m pip install --no-deps --ignore-installed --no-build-isolation --verbose .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,8 @@ requirements:
     - setuptools
     - wheel
     - pybind11 2.10.4
-    - protobuf
+    # required >=3.20.2 but we have only 3.20.3 with python 3.11 support
+    - protobuf 3.20.3
     - libprotobuf
     - pytest-runner 6.0.0
     - numpy   1.19  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - pybind11
+    - pybind11 2.10.4
     - protobuf
     - libprotobuf
     - pytest-runner 6.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,16 @@
 {% set name = "onnx" %}
-{% set version = "1.13.0" %}
-{% set sha256 = "66eb61fc0ff4b6189816eb8e4da52e1e6775a1c29f372cbd08b694aa5b4ca978" %}
+{% set version = "1.13.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/onnx/onnx/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 090d3e10ec662a98a2a72f1bf053f793efc645824f0d4b779e0ce47468a0890e
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - check-model = onnx.bin.checker:check_model
     - check-node = onnx.bin.checker:check_node
@@ -32,7 +31,7 @@ requirements:
     - pybind11
     - protobuf
     - libprotobuf
-    - pytest-runner 4.4
+    - pytest-runner 6.0.0
     - numpy   1.19  # [py<310]
     - numpy   1.21  # [py==310]
     - numpy   1.23  # [py>=311]


### PR DESCRIPTION
Changelog: https://github.com/onnx/onnx/releases
License: https://github.com/onnx/onnx/blob/v1.13.1/LICENSE
Requirements: 
- https://github.com/onnx/onnx/blob/v1.13.1/CMakeLists.txt
- https://github.com/onnx/onnx/blob/v1.13.1/requirements.txt
- https://github.com/onnx/onnx/blob/v1.13.1/setup.py

Actions:
1. Fix build scripts: add shebang to build.sh, add `--no-build-isolation` flag
2. Reset the build number
3. Update pinning for `pytest-runner 6.0.0` because it has **python 3.11** support
