### PR TITLE
PKG-14951: rebuild onnx 1.20.1 against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ded16de1df563d51fbc1ad885f2a426f814039d8b5f4feb77febe09c0295ad67
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - check-model = onnx.bin.checker:check_model
     - check-node = onnx.bin.checker:check_node


### PR DESCRIPTION
onnx 1.20.1

**Destination channel:** Defaults

### Links

- [PKG-14951](https://anaconda.atlassian.net/browse/PKG-14951)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Relevant dependency PRs:
  - AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 — **MERGED**)
  - AnacondaRecipes/repodata-hotfixes#318 (scope reduction — **applied**)

### Explanation of changes:

- **Build number 0 -> 1** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Result:** the new artifact will declare `pybind11-abi ==11` via pybind11-abi's run_export.
- **Why:** onnx exchanges ONNX graph/node C++ types cross-module with onnxruntime. Per Charles's PKG-13552 hotfix-scope analysis, retained in the slim `MISSING_PYBIND11_ABI_VERSION_RANGES` table after #318.

[PKG-14951]: https://anaconda.atlassian.net/browse/PKG-14951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ