### PR TITLE
onnx 1.22.0 

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,10 @@
 set "ONNX_ML=1"
 set CONDA_PREFIX=%LIBRARY_PREFIX%
 set CMAKE_BUILD_TYPE=Release
+set CMAKE_BUILD_PARALLEL_LEVEL=%CPU_COUNT%
+set CMAKE_GENERATOR_PLATFORM=
+set CMAKE_GENERATOR_TOOLSET=
+SET CMAKE_GENERATOR=Ninja
 
 REM MSVC reads CL for all compiles; avoids brittle CMAKE_CXX_FLAGS batch quoting
 set "CL=/DPROTOBUF_USE_DLLS=1 /EHsc /std:c++17 %CL%"
@@ -11,3 +15,16 @@ for /f "usebackq delims=" %%i in (`%PYTHON% -c "import os,subprocess,sys; nb=sub
 
 set USE_MSVC_STATIC_RUNTIME=0
 %PYTHON% -m pip install --no-deps --ignore-installed --no-build-isolation --verbose .
+if errorlevel 1 exit /b 1
+
+cmake -S . -B .setuptools-cmake-build %CMAKE_ARGS% ^
+    -DONNX_BUILD_PYTHON=OFF ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -DONNX_INSTALL=ON
+if errorlevel 1 exit /b 1
+
+cmake --build .setuptools-cmake-build
+if errorlevel 1 exit /b 1
+
+cmake --install .setuptools-cmake-build
+if errorlevel 1 exit /b 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,7 +4,9 @@ set -euxo pipefail
 export ONNX_ML=1
 # build script looks at this, but not set on
 export CONDA_PREFIX="$PREFIX"
-export CMAKE_ARGS="${CMAKE_ARGS} -DBUILD_SHARED_LIBS=ON"
+export CMAKE_BUILD_PARALLEL_LEVEL="${CPU_COUNT}"
+export CMAKE_GENERATOR="Ninja"
+export CMAKE_ARGS="${CMAKE_ARGS}"
 if [[ ${CONDA_BUILD_CROSS_COMPILATION:-} == "1" ]]; then
     export CMAKE_ARGS="${CMAKE_ARGS} -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc"
 else
@@ -23,4 +25,13 @@ if [[ "${target_platform}" == osx-64 ]]; then
     export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 $PYTHON -m pip install --no-deps --ignore-installed --no-build-isolation --verbose .
+
+# The wheel build sets ONNX_INSTALL=OFF, so reconfigure the project
+# to build and install the C++ libraries and CMake package files.
+cmake -S . -B .setuptools-cmake-build ${CMAKE_ARGS} \
+    -DONNX_BUILD_PYTHON=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DONNX_INSTALL=ON
+
+cmake --build .setuptools-cmake-build
 cmake --install .setuptools-cmake-build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,20 @@
 {% set name = "onnx" %}
-{% set version = "1.21.0" %}
+{% set version = "1.22.0" %}
+{% set tests_to_skip = "" %}
+{% set tests_to_skip = tests_to_skip + "test_regex_full_match or test_regex_invalid_pattern" %}
+{% set tests_to_skip = tests_to_skip + " or test_image_decoder_decode_jpeg_bgr_cpu or test_image_decoder_decode_jpeg_rgb_cpu or test_image_decoder_decode_jpeg_grayscale_cpu" %}
 
+# Skip test_regex_full_match and test_regex_invalid_pattern because google-re2 isn't available
+# Skip test_image_decoder_decode_jpeg_bgr_cpu, test_image_decoder_decode_jpeg_rgb_cpu, and test_image_decoder_decode_jpeg_grayscale_cpu
+# because of "AssertionError: Not equal to tolerance rtol=0.001, atol=1e-07",
+# see https://github.com/onnx/onnx/issues/4798
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4d8b67d0aaec5864c87633188b91cc520877477ec0254eda122bef8be43cd764
+  sha256: ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0
   patches:
     - patches/0001-Patch-Python-and-nanobind-cmake-config.patch
     - patches/0002-Link-protobuf-and-abseil-privately.patch
@@ -33,32 +40,25 @@ requirements:
     - python
     - pip
     # upstream [build-system] requires setuptools>=77; pkgs/main satisfies
-    - setuptools
-    - wheel
     - nanobind
     - protobuf {{ libprotobuf }}
     - libprotobuf {{ libprotobuf }}
     - libabseil {{ libabseil }}
     - numpy {{ numpy }}
+    - scikit-build-core >=0.11
+    - protobuf ==4.25.1
   run:
     - python
     - protobuf >=4.25.1
     - numpy >=1.23.2
     - typing-extensions >=4.7.1
-    - ml_dtypes >=0.5.0
+    - ml_dtypes >=0.5.4
     # through run_exports
     - libprotobuf
     - libabseil
+    - typing_extensions >=4.15.0
   run_constrained:
     # upstream [reference] optional extra
-
-{% set tests_to_skip = "" %}
-# Skip test_regex_full_match and test_regex_invalid_pattern because google-re2 isn't available
-{% set tests_to_skip = tests_to_skip + "test_regex_full_match or test_regex_invalid_pattern" %}
-# Skip test_image_decoder_decode_jpeg_bgr_cpu, test_image_decoder_decode_jpeg_rgb_cpu, and test_image_decoder_decode_jpeg_grayscale_cpu
-# because of "AssertionError: Not equal to tolerance rtol=0.001, atol=1e-07",
-# see https://github.com/onnx/onnx/issues/4798
-{% set tests_to_skip = tests_to_skip + " or test_image_decoder_decode_jpeg_bgr_cpu or test_image_decoder_decode_jpeg_rgb_cpu or test_image_decoder_decode_jpeg_grayscale_cpu" %}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,31 +27,25 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - make  # [unix]
     - libprotobuf {{ libprotobuf }}
   host:
     - python
     - pip
-    # upstream [build-system] requires setuptools>=77; pkgs/main satisfies
+    - scikit-build-core >=0.11
     - nanobind
     - protobuf {{ libprotobuf }}
     - libprotobuf {{ libprotobuf }}
     - libabseil {{ libabseil }}
     - numpy {{ numpy }}
-    - scikit-build-core >=0.11
-    - protobuf ==4.25.1
   run:
     - python
     - protobuf >=4.25.1
     - numpy >=1.23.2
-    - typing-extensions >=4.7.1
+    - typing-extensions >=4.15.0
     - ml_dtypes >=0.5.4
     # through run_exports
     - libprotobuf
     - libabseil
-    - typing_extensions >=4.15.0
-  run_constrained:
-    # upstream [reference] optional extra
 
 # Skip test_regex_full_match and test_regex_invalid_pattern because google-re2 isn't available
 {% set tests_to_skip = "test_regex_full_match or test_regex_invalid_pattern" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,8 @@
 {% set name = "onnx" %}
 {% set version = "1.22.0" %}
-{% set tests_to_skip = "" %}
-{% set tests_to_skip = tests_to_skip + "test_regex_full_match or test_regex_invalid_pattern" %}
-{% set tests_to_skip = tests_to_skip + " or test_image_decoder_decode_jpeg_bgr_cpu or test_image_decoder_decode_jpeg_rgb_cpu or test_image_decoder_decode_jpeg_grayscale_cpu" %}
 
-# Skip test_regex_full_match and test_regex_invalid_pattern because google-re2 isn't available
-# Skip test_image_decoder_decode_jpeg_bgr_cpu, test_image_decoder_decode_jpeg_rgb_cpu, and test_image_decoder_decode_jpeg_grayscale_cpu
-# because of "AssertionError: Not equal to tolerance rtol=0.001, atol=1e-07",
-# see https://github.com/onnx/onnx/issues/4798
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -60,6 +53,12 @@ requirements:
   run_constrained:
     # upstream [reference] optional extra
 
+# Skip test_regex_full_match and test_regex_invalid_pattern because google-re2 isn't available
+{% set tests_to_skip = "test_regex_full_match or test_regex_invalid_pattern" %}
+# Skip test_image_decoder_decode_jpeg_bgr_cpu, test_image_decoder_decode_jpeg_rgb_cpu, and test_image_decoder_decode_jpeg_grayscale_cpu
+# because of "AssertionError: Not equal to tolerance rtol=0.001, atol=1e-07",
+# see https://github.com/onnx/onnx/issues/4798
+{% set tests_to_skip = tests_to_skip + " or test_image_decoder_decode_jpeg_bgr_cpu or test_image_decoder_decode_jpeg_rgb_cpu or test_image_decoder_decode_jpeg_grayscale_cpu" %}
 test:
   imports:
     - onnx

--- a/recipe/patches/0001-Patch-Python-and-nanobind-cmake-config.patch
+++ b/recipe/patches/0001-Patch-Python-and-nanobind-cmake-config.patch
@@ -1,20 +1,20 @@
-From bb41150099a906c5977f29180e3ce6e5908054a2 Mon Sep 17 00:00:00 2001
+From eba09c49a4810104a8dfc271f3cfa604428d81bf Mon Sep 17 00:00:00 2001
 From: Christian Bourjau <christian.bourjau@quantco.com>
-Date: Wed, 1 Apr 2026 15:44:36 +0200
-Subject: [PATCH] Patch Python and nanobind cmake config
+Date: Tue, 16 Jun 2026 09:48:49 +0200
+Subject: [PATCH 1/2] Patch Python and nanobind cmake config
 
 Co-authored-by: Mark Harfouche <mark.harfouche@gmail.com>
+Signed-off-by: Christian Bourjau <christian.bourjau@quantco.com>
 ---
- CMakeLists.txt      | 41 +++++------------------------------------
+ CMakeLists.txt      | 39 ++++-----------------------------------
  cmake/summary.cmake | 14 +++++++-------
- setup.py            |  2 +-
- 3 files changed, 13 insertions(+), 44 deletions(-)
+ 2 files changed, 11 insertions(+), 42 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 044996e1b..c2aa00162 100644
+index 791e24bf0..6e82c9d6d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -135,22 +135,8 @@ if(ONNX_BUILD_PYTHON)
+@@ -140,22 +140,8 @@ if(ONNX_BUILD_PYTHON)
    set(python_dev_component Development.Module Development.SABIModule)
  endif()
  
@@ -34,21 +34,12 @@ index 044996e1b..c2aa00162 100644
 -  find_package(Python REQUIRED COMPONENTS Interpreter ${python_dev_component})
 -  set(ONNX_PYTHON_INTERPRETER Python3::Interpreter)
 -endif()
-+find_package(Python REQUIRED COMPONENTS Interpreter Development)
++find_package(Python REQUIRED COMPONENTS Interpreter ${python_dev_component})
 +set(ONNX_PYTHON_INTERPRETER Python::Interpreter)
  
  if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
    set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
-@@ -426,7 +412,7 @@ if(ONNX_BUILD_PYTHON)
-   # find system nanobind
-   if(NOT DEFINED nanobind_DIR OR "${nanobind_DIR}" STREQUAL "")
-     execute_process(
--      COMMAND ${Python_EXECUTABLE} -m nanobind --cmake-dir
-+      COMMAND ${Python_EXECUTABLE} -m nanobind --cmake_dir
-       RESULT_VARIABLE NANOBIND_CMAKE_RESULT
-       OUTPUT_VARIABLE NANOBIND_CMAKE_DIR
-       OUTPUT_STRIP_TRAILING_WHITESPACE
-@@ -435,29 +421,12 @@ if(ONNX_BUILD_PYTHON)
+@@ -541,29 +527,12 @@ if(ONNX_BUILD_PYTHON)
        set(nanobind_DIR "${NANOBIND_CMAKE_DIR}")
      endif()
    endif()
@@ -61,11 +52,11 @@ index 044996e1b..c2aa00162 100644
 -        "FetchContent dependency provider for first-run offline builds.")
 -    endif()
 -    include(FetchContent)
--
+-    sbom_get_dep("nanobind" _nanobind)
 -    FetchContent_Declare(
 -      nanobind
--      GIT_REPOSITORY https://github.com/wjakob/nanobind.git
--      GIT_TAG v2.10.2
+-      GIT_REPOSITORY ${_nanobind_URL}
+-      GIT_TAG v${_nanobind_VERSION}
 -      GIT_SHALLOW TRUE
 -    )
 -    FetchContent_MakeAvailable(nanobind)
@@ -77,14 +68,14 @@ index 044996e1b..c2aa00162 100644
      onnx_cpp2py_export
 -    NB_STATIC NB_DOMAIN onnx STABLE_ABI FREE_THREADED LTO
 +    NB_STATIC NB_DOMAIN onnx FREE_THREADED LTO
-     "${ONNX_ROOT}/onnx/cpp2py_export.cc" ${ONNX_SRCS} ${ONNX_PROTO_SRCS})
-   add_dependencies(onnx_cpp2py_export onnx)
- endif()
+     "${ONNX_ROOT}/onnx/cpp2py_export.cc")
+   # Force-load the whole (static) archive so the operator schemas' static
+   # initializers are not dropped as apparently-unused. $<LINK_LIBRARY:WHOLE_ARCHIVE,...>
 diff --git a/cmake/summary.cmake b/cmake/summary.cmake
-index aadf595c9..cb5e58663 100644
+index f262a3b30..57e39f84f 100644
 --- a/cmake/summary.cmake
 +++ b/cmake/summary.cmake
-@@ -73,14 +73,14 @@ function(onnx_print_configuration_summary)
+@@ -75,14 +75,14 @@ function(onnx_print_configuration_summary)
    endif()
    message(STATUS "  ONNX_BUILD_PYTHON                 : ${ONNX_BUILD_PYTHON}")
    if(ONNX_BUILD_PYTHON)
@@ -106,16 +97,3 @@ index aadf595c9..cb5e58663 100644
      if(Python_SOABI)
        message(STATUS "    Python SOABI                  : ${Python_SOABI}")
      endif()
-diff --git a/setup.py b/setup.py
-index db78bfa2b..2ffbe81d1 100644
---- a/setup.py
-+++ b/setup.py
-@@ -336,7 +336,7 @@ CMD_CLASS = {
- 
- NO_GIL = hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
- PY_312_OR_NEWER = sys.version_info >= (3, 12)
--USE_LIMITED_API = not NO_GIL and PY_312_OR_NEWER and platform.system() != "FreeBSD"
-+USE_LIMITED_API = False and not NO_GIL and PY_312_OR_NEWER and platform.system() != "FreeBSD"
- 
- macros = []
- if USE_LIMITED_API:

--- a/recipe/patches/0002-Link-protobuf-and-abseil-privately.patch
+++ b/recipe/patches/0002-Link-protobuf-and-abseil-privately.patch
@@ -1,27 +1,29 @@
-From 1714692e9d816ccc2f1dcacb236a8514a291cd94 Mon Sep 17 00:00:00 2001
+From 1df756b52570a7cccd8350dc7080555015052e9a Mon Sep 17 00:00:00 2001
 From: Christian Bourjau <christian.bourjau@quantco.com>
-Date: Wed, 1 Apr 2026 17:28:59 +0200
+Date: Tue, 16 Jun 2026 09:51:02 +0200
 Subject: [PATCH 2/2] Link protobuf and abseil privately
 
 Co-authored-by: Mark Harfouche <mark.harfouche@gmail.com>
+Signed-off-by: Christian Bourjau <christian.bourjau@quantco.com>
 ---
  cmake/Utils.cmake | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/cmake/Utils.cmake b/cmake/Utils.cmake
-index 1987edd45..777497bbe 100644
+index 44e306aa3..0b8204061 100644
 --- a/cmake/Utils.cmake
 +++ b/cmake/Utils.cmake
-@@ -135,10 +135,10 @@ function(add_onnx_compile_options target)
+@@ -187,11 +187,11 @@ function(add_onnx_compile_options target)
      ${target}
      PUBLIC $<BUILD_INTERFACE:${ONNX_ROOT}> $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 -  target_link_libraries(${target} PUBLIC ${LINKED_PROTOBUF_TARGET})
 +  target_link_libraries(${target} PRIVATE ${LINKED_PROTOBUF_TARGET})
+   get_target_property(_onnx_linked_protobuf_is_imported ${LINKED_PROTOBUF_TARGET} IMPORTED)
    foreach(ABSL_USED_TARGET IN LISTS protobuf_ABSL_USED_TARGETS)
      if(TARGET ${ABSL_USED_TARGET})
 -      target_link_libraries(${target} PUBLIC ${ABSL_USED_TARGET})
 +      target_link_libraries(${target} PRIVATE ${ABSL_USED_TARGET})
-     endif()
-   endforeach()
-   # Prevent "undefined symbol: _ZNSt10filesystem7__cxx114path14_M_split_cmptsEv"
+       if(NOT _onnx_linked_protobuf_is_imported)
+         add_dependencies(${LINKED_PROTOBUF_TARGET} ${ABSL_USED_TARGET})
+       endif()


### PR DESCRIPTION
onnx 1.22.0 

**Destination channel:** Defaults

### Links

- [PKG-16464]
- dev_url:        https://github.com/onnx/onnx/tree/v1.22.0
- conda_forge:    https://github.com/conda-forge/onnx-feedstock
- pypi:           https://pypi.org/project/onnx/1.22.0
- pypi inspector: https://inspector.pypi.io/project/onnx/1.22.0

### Explanation of changes:

- bump minor version number
- migrate the build backend from **setuptools** to **scikit-build-core**
- add a separate CMake configure/build/install step for C++ libs and CMake package files
- update both downstream patches to apply cleanly against the ONNX 1.22.0 source layout


[PKG-16464]: https://anaconda.atlassian.net/browse/PKG-16464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ