### PR TITLE
rebuild against libprotobuf 7.35.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0002-Link-protobuf-and-abseil-privately.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - check-model = onnx.bin.checker:check_model
     - check-node = onnx.bin.checker:check_node
@@ -27,15 +27,15 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - libprotobuf {{ libprotobuf }}
+    - libprotobuf 7.35.1
   host:
     - python
     - pip
     - scikit-build-core >=0.11
     - nanobind
-    - protobuf {{ libprotobuf }}
-    - libprotobuf {{ libprotobuf }}
-    - libabseil {{ libabseil }}
+    - protobuf 7.35.1
+    - libprotobuf 7.35.1
+    - libabseil 20260526.0
     - numpy {{ numpy }}
   run:
     - python


### PR DESCRIPTION
onnx 1.22.0 - rebuild against libprotobuf 7.35.1

**Destination channel:** defaults

### Links
- [PKG-15936](https://anaconda.atlassian.net/browse/PKG-15936)
- [PyPI](https://pypi.org/project/onnx/1.22.0/)
- [GitHub](https://github.com/onnx/onnx/tree/v1.22.0)

### Explanation of changes:
- Rebuild build 0 → 1 against hardcoded `libabseil 20260526.0` and `libprotobuf 7.35.1` (Stage 005 protobuf migration; aggregate CBC still pins libprotobuf 6.33.5).
- Ticket scoped 1.21.0; main is already at 1.22.0, so this rebuild targets the current release line.

[PKG-15936]: https://anaconda.atlassian.net/browse/PKG-15936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ